### PR TITLE
ToDoモデルを作成 / to_dosテーブルを作成

### DIFF
--- a/app/models/to_do.rb
+++ b/app/models/to_do.rb
@@ -1,0 +1,2 @@
+class ToDo < ApplicationRecord
+end

--- a/db/migrate/20200731060828_create_to_dos.rb
+++ b/db/migrate/20200731060828_create_to_dos.rb
@@ -1,0 +1,9 @@
+class CreateToDos < ActiveRecord::Migration[6.0]
+  def change
+    create_table :to_dos do |t|
+      t.string :title, null: false
+      t.boolean :finished, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_07_31_060828) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "to_dos", force: :cascade do |t|
+    t.string "title", null: false
+    t.boolean "finished", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end


### PR DESCRIPTION
## 該当

- ToDoモデルを作成
- to_dosテーブル作成用のマイグレーションファイルを作成
- 開発環境にto_dosテーブルを作成

### 内容

- `generate`コマンドでToDoモデルとマイグレーションファイルを作成。
- マイグレーションファイルを編集し実行。開発環境にto_dosデータベースを作成。